### PR TITLE
Team page - initial layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,14 @@ jobs:
             git fetch
             git checkout main
             git pull
+            touch .env
+            echo API_URL=${{ secrets.API_URL }} >> .env
+            echo API_KEY=${{ secrets.API_KEY }} >> .env
+            echo NEXT_PUBLIC_ASSET_URL=${{ secrets.NEXT_PUBLIC_ASSET_URL }} >> .env
+            cat .env
             yarn install
             yarn build
+            yarn storybook:build
             pm2 list
             pm2 delete sportdb-react
             pm2 start yarn --name sportdb-react -- start

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -18,15 +18,22 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
+      - name: Create env file
+        run: |
+          touch .env
+          echo API_URL=${{ secrets.API_URL }} >> .env
+          echo API_KEY=${{ secrets.API_KEY }} >> .env
+          echo NEXT_PUBLIC_ASSET_URL=${{ secrets.NEXT_PUBLIC_ASSET_URL }} >> .env
+          cat .env
       - name: Install dependencies
         run: yarn install --immutable
       - name: Run build
-        run: yarn run build
+        run: yarn build
       - name: Run Prettier
-        run: yarn run prettier:check
+        run: yarn prettier:check
       - name: Run lint
-        run: yarn run lint
+        run: yarn lint
       - name: Run typecheck
-        run: yarn run typecheck
+        run: yarn typecheck
       - name: Run Jest
-        run: yarn run jest
+        run: yarn jest

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,7 +3,7 @@ import '@mantine/core/styles.css';
 import React, { useEffect } from 'react';
 import { addons } from '@storybook/preview-api';
 import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
-import { MantineProvider, useMantineColorScheme } from '@mantine/core';
+import { Container, MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { resolver, theme } from '../theme';
 
 export const parameters = {
@@ -31,7 +31,7 @@ export const decorators = [
   (renderStory: any) => <ColorSchemeWrapper>{renderStory()}</ColorSchemeWrapper>,
   (renderStory: any) => (
     <MantineProvider theme={theme} cssVariablesResolver={resolver}>
-      {renderStory()}
+      <Container my="md">{renderStory()}</Container>
     </MantineProvider>
   ),
 ];

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,12 +15,12 @@ export default function RootLayout({ children }: { children: any }) {
   return (
     <html lang="en" {...mantineHtmlProps}>
       <head>
-        <ColorSchemeScript />
+        <ColorSchemeScript defaultColorScheme="auto" />
         <link rel="shortcut icon" href="/favicon.svg" />
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
       </head>
       <body>
-        <MantineProvider theme={theme} cssVariablesResolver={resolver}>
+        <MantineProvider defaultColorScheme="auto" theme={theme} cssVariablesResolver={resolver}>
           <SiteLayout>{children}</SiteLayout>
         </MantineProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,9 +10,21 @@ export default function HomePage() {
         A modest attempt to document, analyse and solve the sport of association football
       </Text>
       <Text ta="center" mt="xl" size="lg">
-        Teams | People | Competitions | Statistics |{' '}
+        <Anchor fw={500} underline="always" href="/teams">
+          Teams
+        </Anchor>{' '}
+        | People | Competitions | Statistics |{' '}
         <Anchor fw={500} underline="always" href="/posts">
           Posts
+        </Anchor>
+      </Text>
+      <Text ta="center" mt="xl" size="lg">
+        <Anchor fw={500} underline="always" href="https://storybook.solving.football">
+          Storybook components
+        </Anchor>{' '}
+        |{' '}
+        <Anchor fw={500} underline="always" href="https://github.com/jonathan-bull/sportdb-react">
+          GitHub repository
         </Anchor>
       </Text>
     </Container>

--- a/app/teams/[id]/page.tsx
+++ b/app/teams/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { Container, Title } from '@mantine/core';
+import { SingleTeamMain } from '@/components/football/team/SingleTeamMain/SingleTeamMain';
+import { apiRequest } from '@/helpers/api/api-request';
+import { SingleTeam } from '@/types/api/Teams';
+
+type teamParams = Promise<{ id: string }>;
+
+export async function generateMetadata({ params }: { params: teamParams }) {
+  const id = (await params).id;
+  const teamData = await apiRequest(`/teams/single/${id}`);
+
+  if (
+    teamData instanceof Error ||
+    Object.hasOwn(teamData, 'teams') === false ||
+    teamData.teams instanceof Array === false ||
+    teamData.teams.length === 0
+  ) {
+    return {
+      title: 'Error - team not found - solving football',
+    };
+  }
+
+  const singleTeam = teamData.teams[0] as SingleTeam;
+
+  return {
+    title: `${singleTeam.names.full}  - solving football`,
+  };
+}
+
+export default async function TeamPage({ params }: { params: teamParams }) {
+  const id = (await params).id;
+  const teamData = await apiRequest(`/teams/single/${id}`);
+
+  // Exit with an error if we haven't got a response.
+  if (
+    teamData instanceof Error ||
+    Object.hasOwn(teamData, 'teams') === false ||
+    teamData.teams instanceof Array === false ||
+    teamData.teams.length === 0
+  ) {
+    return (
+      <Container w="100%">
+        <Title mb="xl">Error - Team not found</Title>
+      </Container>
+    );
+  }
+
+  const singleTeam = teamData.teams[0] as SingleTeam;
+
+  return (
+    <Container w="100%" mt="sm" mb="sm">
+      <SingleTeamMain singleTeam={singleTeam} />
+    </Container>
+  );
+}

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -1,0 +1,45 @@
+import { Container, Text, Title } from '@mantine/core';
+import { ListTeam } from '@/components/football/team/ListTeam/ListTeam';
+import { apiRequest } from '@/helpers/api/api-request';
+import { convertTeamForDisplay } from '@/helpers/football/convertForDisplay';
+import { SingleTeam } from '@/types/api/Teams';
+import { DisplayEntity } from '@/types/display/Teams';
+
+export function generateMetadata() {
+  return {
+    title: 'Teams - solving.football',
+    description: 'Teams available in the database',
+  };
+}
+
+export default async function TeamsPage() {
+  // This will by dynamic some day.
+  const listLimit = 10;
+  const displayError = 'No teams returned from the API.';
+  let processedData: SingleTeam[] = [];
+  let displayTeams: DisplayEntity[] = [];
+
+  const teamsData = await apiRequest('/teams', { limit: listLimit.toString() });
+
+  if (teamsData instanceof Error === false && 'teams' in teamsData) {
+    processedData = teamsData.teams as SingleTeam[];
+    displayTeams = processedData.map((singleTeam) => {
+      return convertTeamForDisplay(singleTeam);
+    });
+  }
+
+  return (
+    <>
+      <Container w="100%">
+        <Title mt="md" mb="xl">
+          Teams
+        </Title>
+        {displayTeams.length === 0 ? (
+          <Text>{displayError}</Text>
+        ) : (
+          <ListTeam displayTeams={displayTeams} />
+        )}
+      </Container>
+    </>
+  );
+}

--- a/blog/hello-world.mdx
+++ b/blog/hello-world.mdx
@@ -48,7 +48,7 @@ I've broken the whole thing down step by step. There's no JIRA board, but there'
 
 * [first steps](/posts/first-steps) - setting up a simple site with Mantine and Next.JS that deploys to Digital Ocean via GitHub
 * [building a blog](/posts/building-a-blog) - creating a simple blog that displays Markdown data
-* a simple team page - a page that pulls in simple data from an API and renders it on the page
+* [a simple team page](/posts/team-building-exercise) - a page that pulls in simple data from an API and renders it on the page
 * expanding the team page - adding more components to the team page, including kit displays
 * fixture lists - listing a team's fixtures, allowing filtering and pagination
 * fixture list page - extending the fixture list to be used on its own page

--- a/blog/team-building-exercise.mdx
+++ b/blog/team-building-exercise.mdx
@@ -1,0 +1,253 @@
+---
+title: 'Team building exercise'
+description: 'Rendering simple data received from the API'
+publishDate: '2025-04-28T08:30:00Z'
+published: true
+---
+
+import { SingleContentTitle } from '@/components/football/content/SingleContentTitle/SingleContentTitle';
+
+# Team building exercise
+
+We have a site. We have an API. Now we need to connect one with the other.
+
+I've picked teams to begin with, as they're the basis of pretty much everything else we're going to build. Fixtures involve two teams, competitions are made up of multiple teams and people are typically attached to at least one team.
+
+So, the aim here is to build:
+- a means of querying the API and returning data
+- a list of multiple teams with simple data
+- a single team page, giving more detail about a team
+
+## Old To Begin
+
+As mentioned in [previous blogs](/posts/hello-world), I've had an API for a while. Most recently, I've switched from using Flask-API to [Fast API](https://fastapi.tiangolo.com/) and rewrote things to be a bit more performant. It's restricted via an API key and rate limited by the excellently named Fast API addon, [Slow API](https://slowapi.readthedocs.io/en/latest/).
+
+I've not needed to do much with it as part of this work, but I did add in some automated deployment, thanks to what I learnt from deploying this app to my DigitalOcean droplet.
+
+Hopefully, it's visible in [the documentation](https://api.solving.football/docs), but my API has:
+- a `/teams/` route - returning all teams based on any limits, paging and querying passed
+- a `/teams/single/<id>` route - returning a single team based on the ID
+
+Both routes give a similar response: a `teams` array containing individual team items.
+
+Each individual team response contains:
+- `id` - a unique number identifying our team
+- `name` - a simple team name
+- `logo` - a URL for the team's logo
+- `type` - whether the team is a club or a nation
+- `colours` - an array of colours associated to the team
+- `competitionHistory` - an array of competitions the team has appeared in
+- `leagueTable` - an object containing the team's current competition and their position in it
+- `mapping` - an array of IDs the team has in other sources
+- `names` - an array containing various names associated with the team
+
+This is a lot of information - too much, especially on the multiple team route, if we're honest. 
+
+What it gives us is a solid, reusable structure of data that we can use to display data about individual teams and multiple teams at once.
+
+Now, we just need to get it out of the API.
+
+## Transport is Arranged
+
+There's going to be a lot of hitting the API, and it's going to be done fairly consistently. It's always going to hit the same base with some sort of extension. We're always going to need to pass the API key as a header, as well as a caching header to avoid spamming the server. Sometimes, we're going to pass query parameters as an object and make use of [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to convert them to a string.
+
+With that fairly solidly planned out, it's time to build a `fetch` request wrapped in a `try` and `catch` condition.
+
+Typing a `fetch` request is tricky. I don't want to be overly specific and end up with errors from valid responses. I also don't want to be vague and use an `Any` type, otherwise, why bother with types at all? I've opted for a `JSONObject|Error` return from my function, with `JSONObject` following that old programming tradition: [stolen wholesale from a Stack Overflow question](https://stackoverflow.com/a/64117261).
+
+A few simple tests of this returned the expected data from the API. That'll do for now, I guess. There's no test coverage. Got a bit scared of where to even start with that. Decided to just plough on regardless and maybe come back to it another time.
+
+## Type Slowly
+
+The main advantage TypeScript brings is a deep knowledge of data in any context. This is a particular benefit to JavaScript, as many a simple script has broken a front end due to an undefined element. But it's especially helpful when dealing with complex but consistent data structures like, for example, the type you get from an API.
+
+The main disadvantage of TypeScript, though, is this is all a lot of effort, especially at the start. Much like testing, it improves the stability and reliability of the code base at the expense of how long it takes to make stuff.
+
+In this particular context, the advantages far outweight the disadvantages. Typing data that comes out of the API and goes into the React components means we can take something approaching an MVC approach. Our API logic can focus entirely on receiving data, passing it to a validator/controller. This means the amount of logic in our components is hugely reduced and only impacts rendering.
+
+With my generic `JSONObject` type ready, I built a variety of types based around the API's response to ensure that's consistent.
+
+## Major Leagues
+
+With Next.JS, it's nice and easy to set up a page based on the ID. We already do the same thing for these blog posts.
+
+On the page, we use the API to grab the data from the API and convert it into a sensible shape for our use in the page. 
+
+The main things we want to do is get a sensible display name and the team's current colours. Our `colours` object contains multiple RGB colours for each competition the team has been involved in, subject to availability.
+
+**Side note:** this is done by a script that picks the four most prominent colours in an image of a kit. This gets converted into RGB values and a split of how prominent colours are in the image. It's pretty neat.
+
+Throwing the raw API data into a converter reduces the logic we need to use in components and means we can loop through multiple teams.
+
+And the key component we need is a title that summarises the team.
+
+<SingleContentTitle 
+    nameDisplay='Cardiff City'
+    nameCode='CDF'
+    colourBackground='#00f'
+    colourText='#fff'
+    detailStart='1st'
+    detailEnd='the Premier League 2024/2025'
+    image='https://dlskitshub.com/wp-content/uploads/Cardiff-City-FC-Logo-PNG-DLS.png'
+/>
+
+The top half displays the team, the lower displays a summary of their current state. We can also pass colours, flipping them when switching between dark and light modes.
+
+That's the happy path, where all of the data exists, but it's reasonable that none of the data exists. 
+
+In this instance, we use default colours and do not display the 'detail' section at all.
+
+<SingleContentTitle 
+    nameDisplay='Cardiff City'
+/>
+
+## Two States
+
+In order to navigate through the teams, there needs to be a landing page. Again, that's nice and easy to set up, as we just hit the plain `/teams` route to get data. In order to keep things relatively performant, we limit to 10 teams by default.
+
+Since we have the same data returned, we can process it in the same way and receive the same data used in the component built for the individual team page. That means, we can create a list by iterating over the data and passing it into our existing component.
+
+By default, it's a bit too tall to be used in a list. The more information on the page at once the better, in this context.
+
+So, with some additional styling and a `size` prop set to `small`, there's a variation.
+
+import { Stack } from '@mantine/core';
+
+<Stack gap="xs" mb="lg">
+    <SingleContentTitle 
+        nameDisplay='Cardiff City'
+        nameCode='CDF'
+        colourBackground='#00f'
+        colourText='#fff'
+        detailStart='1st'
+        detailEnd='the Premier League 2024/2025'
+        image='https://dlskitshub.com/wp-content/uploads/Cardiff-City-FC-Logo-PNG-DLS.png'
+        size='small'
+    />
+
+    <SingleContentTitle 
+        nameDisplay='Swansea City'
+        nameCode='SWA'
+        colourBackground='#fff'
+        colourText='#000'
+        detailStart='2nd'
+        detailEnd='the Premier League 2024/2025'
+        image='https://i2-prod.walesonline.co.uk/incoming/article15179090.ece/ALTERNATES/s615b/0_old-logo.png'
+        size='small'
+    />
+
+    <SingleContentTitle 
+        nameDisplay='Wrexham'
+        nameCode='WRE'
+        colourBackground='#f00'
+        colourText='#fff'
+        detailStart='3rd'
+        detailEnd='the Premier League 2024/2025'
+        image='https://toptensfun.s3.eu-south-1.amazonaws.com/photos/user_1/Top%2010%20Best%20Soccer%20Clubs%20Playing%20in%20Leagues%20of%20Another%20Country/Wrexham-AFC-logo.png'
+        size='small'
+    />
+</Stack>
+
+This is a bit wide, though. It's probably better to have this as a card, so three or four can be shown in a single row. Ideally, it'll be something that can be switched between too.
+
+
+## Brighten the Corners
+
+Thanks to Storybook, it's nice and easy to see the component in isolation. By stripping the component of its context, the edge cases become much clearer. And in using stories with different arguments, testing those edge cases is simple. 
+
+For example, we can add very long details:
+
+<SingleContentTitle 
+    nameDisplay='Cardiff City'
+    nameCode='CDF'
+    colourBackground='#00f'
+    colourText='#fff'
+    detailStart='1st'
+    detailEnd='First Annual Montgomery Burns Award for Outstanding Achievement in the Field of Excellence'
+    image='https://dlskitshub.com/wp-content/uploads/Cardiff-City-FC-Logo-PNG-DLS.png'
+/>
+
+And very long team names:
+
+<SingleContentTitle 
+    nameCode='Borussia Mönchengladbach'
+    nameDisplay='Borussia Mönchengladbach'
+    detailStart='9th'
+    detailEnd='the Bundesliga'
+    image='https://www.bundesliga.com/assets/clublogo/DFL-CLU-000004.svg'
+/>
+
+This also takes SVGs. I hadn't even found that out until now. Nice one, Mantine.
+
+Test driving components in context can be tricky - forcing various types of objects into your component and seeing what it does. With Storybook, it's a case of deleting or changing arguments passed through. When the barrier to testing is that low, it's rude not to try everything possible combination.
+
+At some point, it might even be worth building fixtures to throw into the components. Maybe not at this early stage, though.
+
+## Grave Architecture
+
+Throwing things at the component in Storybook made it much more flexible. That flexibility got me thinking about other possibilities.
+
+There's going to be a lot more 'list' contexts in this project. There's going to be lists of people and lists of competitions. There will also be competition tables and fixture lists, but those contexts are different enough to warrant unique components.
+
+Displaying competitions and people, though, could be handled by the same component. That applies to their own pages and within lists too.
+
+So, with some refactoring, it was possible to expand the component somewhat. The bulk of the work involved any time I'd used `team` and converting the separator between a team's position and its current competition. This led to even less logic living in the component.
+
+And as a result, we can list people:
+
+<SingleContentTitle 
+    nameCode='AR'
+    nameDisplay='Aaron Ramsey'
+    image='https://www.fifarosters.com/assets/players/fifa24/faces/186561.png'
+    detailStart='Attacking midfielder'
+    detailEnd='Cardiff City and Wales'
+    detailSeparator='for'
+/>
+
+As well as competitions:
+
+<SingleContentTitle 
+    nameCode='EPL'
+    nameDisplay='The Premier League'
+    image='https://logodownload.org/wp-content/uploads/2016/03/premier-league-5.png'
+    detailStart='First tier competition'
+    detailEnd='England'
+    detailSeparator='in'
+    size='small'
+/>
+
+No pages for either of those yet. We'll come to those another time.
+
+## Harness Your Hopes
+
+So, that's an API connection complete and some basic functionality in place. I've made: 
+- a component for handling team, then rebuilt it so it's reusable in a number of sensible contexts
+- some [Storybook stories](https://storybook.solving.football/) that push the edges of the component
+- a [team page](/teams/414) that shows some simple information about a team
+- a [team list page](/teams) that gets a limited amount of data from the API and renders it on the page
+- this write up of the whole adventure
+
+You'd hope I'd be pleased with this, but not quite. What stands out most is what's not worked:
+
+- test coverage is a bit shallow where it does exist
+- no component testing
+- the API request function mostly covers the happy path
+- it would be nice if that 'team' component had a separate 'card' or 'grid' layout
+- the list layout doesn't handle pagination
+- using Pavement song titles as headings has been a bit forced at times here
+
+Writing these things up after the fact , coupled with a lifetime of pessimism, makes these shortcomings stand out. I can't shake the feeling anyone looking at this might think 'is that it?'.
+
+But sometimes software development is just throwing _something_ into production. 
+
+I've built something. It's not perfect, but it's on the internet. I could spend significantly more time making it something I'm happy with, but not releasing anything that whole time. Perfect is the enemy of good, and all that.
+
+So, what we have are more foundations.
+
+The team page shows some basic team data. It is missing details like current squad members, fixtures, historic competition involvement and so on. But it does display some basics. Plenty of room for improvement.
+
+The team list shows a number of teams. It's missing pagination, filters and searching. But it does list teams from the API and the overall structure can be reused for other contexts like listing competitions and people.
+
+At these early stages, it's more difficult to limit scope. The possibilities and opportunitues are so broad. It's incredibly easy to get lost by digging deeply into one narrow element. On occasion, it's fun too.
+
+So, next time, the focus is going to be really limited and narrow. The team page is going to get some kit displays. It's going to have a dropdown for selecting each competition and it's going to handle data being missing.

--- a/components/blog/BlogList/BlogList.story.tsx
+++ b/components/blog/BlogList/BlogList.story.tsx
@@ -1,4 +1,6 @@
-import { MetadataObj } from '@/types/MetadataObj';
+import type { Meta } from '@storybook/react';
+import { Container } from '@mantine/core';
+import type { MetadataObj } from '@/types/MetadataObj';
 import BlogList from './BlogList';
 
 const singleListItem: MetadataObj = {
@@ -19,29 +21,41 @@ LongTitleListItem.title =
 const unpublishedListItem = { ...singleListItem };
 unpublishedListItem.published = false;
 
-export default {
-  title: 'BlogList',
+const meta: Meta = {
+  title: 'Blog list',
   component: BlogList,
+  decorators: [
+    (Story) => (
+      <Container my="md">
+        <Story />
+      </Container>
+    ),
+  ],
   args: {
     postList: new Array(6).fill(singleListItem),
   },
 };
 
-export const Default = {};
+export default meta;
+
+export const Default = meta;
 
 export const oddNumber = {
+  ...meta,
   args: {
     postList: new Array(5).fill(singleListItem),
   },
 };
 
 export const unpublishedData = {
+  ...meta,
   args: {
     postList: new Array(5).fill(unpublishedListItem),
   },
 };
 
 export const WithOneLongTitleItem = {
+  ...meta,
   args: {
     postList: [
       ...new Array(2).fill(singleListItem),
@@ -52,6 +66,7 @@ export const WithOneLongTitleItem = {
 };
 
 export const WithOneNoPublishDateItem = {
+  ...meta,
   args: {
     postList: [
       ...new Array(2).fill(singleListItem),

--- a/components/blog/BlogListItem/BlogListItem.story.tsx
+++ b/components/blog/BlogListItem/BlogListItem.story.tsx
@@ -1,8 +1,17 @@
+import type { Meta } from '@storybook/react';
+import { Container } from '@mantine/core';
 import { BlogListItem } from './BlogListItem';
 
-export default {
-  title: 'BlogListItem',
+const meta: Meta = {
+  title: 'Blog list item',
   component: BlogListItem,
+  decorators: [
+    (Story) => (
+      <Container my="md">
+        <Story />
+      </Container>
+    ),
+  ],
   args: {
     slug: 'hello-world',
     title: 'Hello world!',
@@ -12,15 +21,19 @@ export default {
   },
 };
 
-export const Default = {};
+export default meta;
+
+export const Default = meta;
 
 export const LongTitle = {
+  ...meta,
   args: {
     title: 'Doctor Storybook or: How I Learned to Stop Worrying and Love Component Testing',
   },
 };
 
 export const LongDescription = {
+  ...meta,
   args: {
     // Moby Dick is public domain.
     description:
@@ -29,18 +42,21 @@ export const LongDescription = {
 };
 
 export const NoDate = {
+  ...meta,
   args: {
     publishDate: null,
   },
 };
 
 export const NoSlug = {
+  ...meta,
   args: {
     slug: null,
   },
 };
 
 export const Unpublished = {
+  ...meta,
   args: {
     published: false,
   },

--- a/components/football/content/SingleContentTitle/SingleContentTitle.module.css
+++ b/components/football/content/SingleContentTitle/SingleContentTitle.module.css
@@ -1,0 +1,35 @@
+.title {
+    font-size: 1.25rem;
+    text-overflow: ellipsis;
+    overflow: hidden;
+
+    @media (min-width: 36em) {
+        font-size: 2rem;
+    }
+}
+
+.title--small {
+    font-size: 1rem;
+    text-overflow: ellipsis;
+    overflow: hidden;
+
+    @media (min-width: 36em) {
+        font-size: 1.25rem;
+    }
+}
+
+.subtitle {
+    font-size: 1rem;
+
+    @media (min-width: 36em) {
+        font-size: 1.25rem;
+    }
+}
+
+.subtitle--small {
+    font-size: .8rem;
+
+    @media (min-width: 36em) {
+        font-size: 1rem;
+    }
+}

--- a/components/football/content/SingleContentTitle/SingleContentTitle.story.tsx
+++ b/components/football/content/SingleContentTitle/SingleContentTitle.story.tsx
@@ -1,0 +1,100 @@
+import type { Meta } from '@storybook/react';
+import { SingleContentTitle } from './SingleContentTitle';
+
+const meta: Meta = {
+  title: 'Single content title',
+  component: SingleContentTitle,
+  decorators: [(Story) => <Story />],
+  args: {
+    nameDisplay: 'Cardiff City',
+    image: 'https://dlskitshub.com/wp-content/uploads/Cardiff-City-FC-Logo-PNG-DLS.png',
+    nameCode: 'CDF',
+    detailStart: '1st',
+    detailEnd: 'the Premier League 2024/2025',
+  },
+};
+
+export default meta;
+
+export const Default = meta;
+
+export const Small = {
+  ...meta,
+  args: {
+    size: 'small',
+  },
+};
+
+export const NoBorder = {
+  ...meta,
+  args: {
+    hasBorder: false,
+  },
+};
+
+export const WithColour = {
+  ...meta,
+  args: {
+    colourBackground: '#00f',
+    colourText: '#fff',
+  },
+};
+
+const personArgs = {
+  nameCode: 'AR',
+  nameDisplay: 'Aaron Ramsey',
+  image: 'https://www.fifarosters.com/assets/players/fifa24/faces/186561.png',
+  detailStart: 'Attacking midfielder',
+  detailEnd: 'Cardiff City and Wales',
+  detailSeparator: 'for',
+};
+
+const personMeta = {
+  ...meta,
+  args: personArgs,
+};
+
+export const Person = personMeta;
+
+export const PersonWithColour = {
+  ...personMeta,
+  args: {
+    ...personArgs,
+    colourBackground: '#f00',
+    colourText: '#fff',
+  },
+};
+
+export const PersonSmall = {
+  ...personMeta,
+  args: {
+    ...personArgs,
+    size: 'small',
+  },
+};
+
+export const LongNames = {
+  ...meta,
+  args: {
+    nameCode: 'Borussia Mönchengladbach',
+    nameDisplay: 'Borussia Mönchengladbach',
+  },
+};
+
+export const NoNames = {
+  ...meta,
+  args: {
+    nameCode: null,
+    nameDisplay: null,
+  },
+};
+
+export const LongCompetitionName = {
+  ...meta,
+  args: {
+    detailStart: 'Winner',
+    detailSeparator: 'of the',
+    detailEnd:
+      'First Annual Montgomery Burns Award for Outstanding Achievement in the Field of Excellence',
+  },
+};

--- a/components/football/content/SingleContentTitle/SingleContentTitle.tsx
+++ b/components/football/content/SingleContentTitle/SingleContentTitle.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import {
+  Avatar,
+  Card,
+  Divider,
+  Flex,
+  Grid,
+  GridCol,
+  Text,
+  Title,
+  useMantineColorScheme,
+} from '@mantine/core';
+import classes from './SingleContentTitle.module.css';
+
+type SingleContentProps = {
+  colourBackground?: string;
+  colourText?: string;
+  detailEnd?: string;
+  detailStart?: string;
+  detailSeparator?: string;
+  nameCode?: string;
+  nameDisplay?: string;
+  image?: string;
+  size?: string;
+  hasBorder?: boolean;
+};
+
+export function SingleContentTitle(props: SingleContentProps) {
+  const {
+    colourBackground = 'white',
+    colourText = 'black',
+    detailEnd = '',
+    detailSeparator = 'in',
+    detailStart = '',
+    nameCode,
+    nameDisplay,
+    image,
+    size = 'normal',
+    hasBorder = true,
+  } = props;
+
+  // Default code name - first three letters of display name.
+  // Trim code name to three characters and
+  const displayNameCode = nameCode ? nameCode : nameDisplay;
+  const { colorScheme } = useMantineColorScheme();
+
+  const usingDefaultColourValues = colourBackground === 'white' && colourText === 'black';
+  const useDefaultColourPalette = usingDefaultColourValues === false && colorScheme !== 'dark';
+
+  const displayBackground = useDefaultColourPalette ? colourBackground : colourText;
+  const displayText = useDefaultColourPalette ? colourText : colourBackground;
+  const displayBorder = useDefaultColourPalette ? colourText : colourBackground;
+
+  return (
+    <Card
+      c={displayText}
+      bg={displayBackground}
+      p={size === 'small' ? '.5rem' : 'sm'}
+      bd={hasBorder ? `1px solid ${displayBorder}` : ``}
+    >
+      <Grid gutter={size === 'small' ? 'xs' : 'sm'} align="center">
+        <GridCol
+          span={{
+            base: size === 'small' ? 2 : 4,
+            xs: size === 'small' ? 1 : 2,
+          }}
+        >
+          <Avatar
+            h="auto"
+            radius="xs"
+            w="auto"
+            alt={size === 'normal' ? nameDisplay : 'Logo'}
+            src={image}
+          >
+            {displayNameCode?.substring(0, 3).toUpperCase()}
+          </Avatar>
+        </GridCol>
+        <GridCol
+          span={{
+            base: size === 'small' ? 10 : 8,
+            xs: size === 'small' ? 11 : 10,
+          }}
+        >
+          <Flex direction="column" gap={size === 'small' ? '.5rem' : 'xs'}>
+            <Title
+              className={size === 'small' ? classes['title--small'] : classes.title}
+              order={2}
+              size="h4"
+              textWrap="balance"
+            >
+              {nameDisplay}
+            </Title>
+            {detailStart && (
+              <>
+                <Divider bd={`1px solid ${displayBorder}`} />
+                <Text className={size === 'small' ? classes['subtitle--small'] : classes.subtitle}>
+                  {detailEnd !== '' ? (
+                    <>
+                      {detailStart} {detailSeparator} {detailEnd}
+                    </>
+                  ) : (
+                    <>{detailStart}</>
+                  )}
+                </Text>
+              </>
+            )}
+          </Flex>
+        </GridCol>
+      </Grid>
+    </Card>
+  );
+}

--- a/components/football/team/ListTeam/ListTeam.story.tsx
+++ b/components/football/team/ListTeam/ListTeam.story.tsx
@@ -1,0 +1,48 @@
+import type { Meta } from '@storybook/react';
+import { ListTeam } from './ListTeam';
+
+const meta: Meta = {
+  title: 'List of teams',
+  component: ListTeam,
+  decorators: [(Story) => <Story />],
+  args: {
+    displayTeams: [
+      {
+        id: 123,
+        displayName: 'Cardiff City',
+        teamLogo: 'https://dlskitshub.com/wp-content/uploads/Cardiff-City-FC-Logo-PNG-DLS.png',
+        codeName: 'CDF',
+        detailStart: '1st',
+        detailEnd: 'the Premier League 2024/2025',
+      },
+      {
+        id: 456,
+        displayName: 'Swansea City',
+        teamLogo: 'https://e0.365dm.com/football/badges/96/375.png',
+        codeName: 'SWA',
+        detailStart: '1st',
+        detailEnd: 'the Championship 2024/2025',
+      },
+      {
+        id: 789,
+        displayName: 'Wrexham',
+        teamLogo:
+          'https://cdn.freebiesupply.com/logos/large/2x/wrexham-afc-logo-png-transparent.png',
+        codeName: 'WRE',
+        detailStart: '1st',
+        detailEnd: 'League One 2024/2025',
+      },
+    ],
+  },
+};
+
+export default meta;
+
+export const Default = meta;
+
+export const Small = {
+  ...meta,
+  args: {
+    displayTeams: [],
+  },
+};

--- a/components/football/team/ListTeam/ListTeam.tsx
+++ b/components/football/team/ListTeam/ListTeam.tsx
@@ -1,0 +1,35 @@
+import { Anchor, Stack, Title } from '@mantine/core';
+import { SingleContentTitle } from '@/components/football/content/SingleContentTitle/SingleContentTitle';
+import { DisplayEntity } from '@/types/display/Teams';
+
+type ListTeamProps = {
+  displayTeams: DisplayEntity[] | [];
+};
+
+export function ListTeam(props: ListTeamProps) {
+  const { displayTeams } = props;
+
+  if (displayTeams.length === 0) {
+    return <Title>No teams found</Title>;
+  }
+
+  return (
+    <Stack gap="xs" mb="lg">
+      {displayTeams.map((displayTeam) => (
+        <Anchor key={displayTeam.id} href={`/teams/${displayTeam.id}`} underline="never">
+          <SingleContentTitle
+            size="small"
+            key={displayTeam.id}
+            colourBackground={displayTeam.bgColour}
+            colourText={displayTeam.textColour}
+            detailStart={displayTeam.detailStart}
+            detailEnd={displayTeam.detailEnd}
+            nameCode={displayTeam.codeName}
+            nameDisplay={displayTeam.displayName}
+            image={displayTeam.teamLogo}
+          />
+        </Anchor>
+      ))}
+    </Stack>
+  );
+}

--- a/components/football/team/SingleTeamMain/SingleTeamMain.tsx
+++ b/components/football/team/SingleTeamMain/SingleTeamMain.tsx
@@ -1,0 +1,38 @@
+import { Stack } from '@mantine/core';
+import { SingleContentTitle } from '@/components/football/content/SingleContentTitle/SingleContentTitle';
+import { SingleTeamMapping } from '@/components/football/team/SingleTeamMapping/SingleTeamMapping';
+import { SingleTeamNames } from '@/components/football/team/SingleTeamNames/SingleTeamNames';
+import { convertTeamForDisplay } from '@/helpers/football/convertForDisplay';
+import { DisplayTeam } from '@/types/display/Teams';
+
+type SingleTeamProps = {
+  singleTeam: DisplayTeam;
+};
+
+export function SingleTeamMain(props: SingleTeamProps) {
+  const { singleTeam } = props;
+
+  const displayTeam = convertTeamForDisplay(singleTeam);
+  return (
+    <Stack>
+      <SingleContentTitle
+        colourBackground={displayTeam.bgColour}
+        colourText={displayTeam.textColour}
+        detailStart={displayTeam.detailStart}
+        detailEnd={displayTeam.detailEnd}
+        nameCode={displayTeam.codeName}
+        nameDisplay={displayTeam.displayName}
+        image={displayTeam.teamLogo}
+      />
+      <SingleTeamNames
+        full={singleTeam.names.full}
+        short={singleTeam.names.short}
+        display={singleTeam.names.display}
+        shortAlt={singleTeam.names.shortAlt}
+        code={singleTeam.names.code}
+        nickName={singleTeam.names.nickName}
+      />
+      {singleTeam.mapping && <SingleTeamMapping teamMapping={singleTeam.mapping} />}
+    </Stack>
+  );
+}

--- a/components/football/team/SingleTeamMapping/SingleTeamMapping.tsx
+++ b/components/football/team/SingleTeamMapping/SingleTeamMapping.tsx
@@ -1,0 +1,51 @@
+import { Anchor, Card, Flex, Stack, Text, Title } from '@mantine/core';
+import { TeamMapping } from '@/types/api/Teams';
+
+export function SingleTeamMapping(props: { teamMapping: TeamMapping[] }) {
+  const { teamMapping } = props;
+
+  // Filter out empty.
+  const filteredMapping = teamMapping.filter((singleMap) => {
+    return Object.hasOwn(singleMap, 'sourceName') && Object.hasOwn(singleMap, 'sourceID');
+  });
+
+  const displayMapping = filteredMapping.map((singleMap, mapInd) => (
+    <Stack key={mapInd}>
+      <Flex columnGap="sm" justify="space-between" direction={{ base: 'column', sm: 'row' }}>
+        <Flex w="100%" justify="space-between" align="center">
+          <Text tt="uppercase" size="xs">
+            Source
+          </Text>
+          <Text fw={700}>{singleMap.sourceName}</Text>
+        </Flex>
+        <Flex w="100%" justify="space-between" align="center">
+          <Text tt="uppercase" size="xs">
+            ID
+          </Text>
+          {singleMap.sourceURL && (
+            <Anchor fw={700} underline="always" href={singleMap.sourceURL} target="_blank">
+              {singleMap.displayName} ({singleMap.sourceID})
+            </Anchor>
+          )}
+          {singleMap.sourceURL === '' && (
+            <Text fw={700}>
+              {singleMap.displayName} ({singleMap.sourceID})
+            </Text>
+          )}
+        </Flex>
+      </Flex>
+    </Stack>
+  ));
+
+  return (
+    <>
+      <Title order={4} c="white">
+        Team data sources
+      </Title>
+      <Card bd="1px solid white" c="white" bg="transparent">
+        {filteredMapping.length === 0 && <Text>No mapping available for this team.</Text>}
+        {filteredMapping.length > 0 && displayMapping}
+      </Card>
+    </>
+  );
+}

--- a/components/football/team/SingleTeamNames/SingleTeamNames.tsx
+++ b/components/football/team/SingleTeamNames/SingleTeamNames.tsx
@@ -1,0 +1,60 @@
+import { Card, Group, Text, Title } from '@mantine/core';
+import { TeamNames } from '@/types/api/Teams';
+
+export function SingleTeamNames(props: TeamNames) {
+  const { full, display, short, shortAlt, nickName, code } = props;
+
+  const nameData = [
+    {
+      key: 'display',
+      label: 'Display name',
+      value: display,
+    },
+    {
+      key: 'full',
+      label: 'Full name',
+      value: full,
+    },
+    {
+      key: 'short',
+      label: 'Short name',
+      value: short,
+    },
+    {
+      key: 'shortAlt',
+      label: 'Alternative short name',
+      value: shortAlt,
+    },
+    {
+      key: 'nickName',
+      label: 'Nickname',
+      value: nickName,
+    },
+    {
+      key: 'codeName',
+      label: 'Code name',
+      value: code,
+    },
+  ];
+
+  const nameList = nameData.map((singleName) => (
+    <Group key={singleName.key} align="center" justify="space-between">
+      <Text tt="uppercase" size="xs">
+        {singleName.label}
+      </Text>
+      {singleName.value && <Text fw={700}>{singleName.value}</Text>}
+      {!singleName.value && <Text fw={200}>Not set</Text>}
+    </Group>
+  ));
+
+  return (
+    <>
+      <Title order={4} c="white">
+        Team names
+      </Title>
+      <Card bd="1px solid white" bg="transparent">
+        {nameList}
+      </Card>
+    </>
+  );
+}

--- a/components/furniture/SiteNav/SiteNav.tsx
+++ b/components/furniture/SiteNav/SiteNav.tsx
@@ -9,6 +9,7 @@ type siteNavLink = {
 export function SiteNav() {
   const siteNavLinks: siteNavLink[] = [
     { label: 'Home', slug: '/' },
+    { label: 'Teams', slug: '/teams' },
     { label: 'Posts', slug: '/posts' },
   ];
 

--- a/helpers/api/api-request.tsx
+++ b/helpers/api/api-request.tsx
@@ -1,0 +1,52 @@
+import { JSONObject } from '@/types/api/Generic';
+
+type queryObject = { [index: string]: string };
+
+/**
+ * Wrapper for fetching data from the API.
+ *
+ * @param {string} apiPath The API path to query.
+ * @param {queryObject} queryParams An object containing key value pairs, used as URL params.
+ *
+ * @return {Promise<JSONObject|Error>} The resolved promise of a JSONValue or an error.
+ */
+export async function apiRequest(
+  apiPath: string,
+  queryParams: queryObject = {},
+  useCache: boolean = true
+): Promise<JSONObject | Error> {
+  try {
+    const URLparams = new URLSearchParams(queryParams).toString();
+    const apiHeaders = new Headers();
+
+    // Exit early if there's no API key set.
+    if (typeof process.env.API_KEY === 'undefined' || process.env.API_KEY === null) {
+      return {};
+    }
+
+    apiHeaders.append('x-api-key', process.env.API_KEY);
+
+    if (useCache === true) {
+      apiHeaders.append('cache', 'force-cache');
+    }
+
+    const response = await fetch(`${process.env.API_URL}${apiPath}?${URLparams}`, {
+      method: 'GET',
+      headers: apiHeaders,
+    });
+
+    // Check we have a response and that response is JSON.
+    if (response.ok && response.headers.get('content-type')?.includes('application/json')) {
+      return await response.json();
+    }
+
+    // If we are here for some reason, return null.
+    return {};
+  } catch (error) {
+    if (typeof error === 'string') {
+      throw new Error(error);
+    }
+
+    throw new Error('Unknown error occurred');
+  }
+}

--- a/helpers/blog/fetchPostData.tsx
+++ b/helpers/blog/fetchPostData.tsx
@@ -25,7 +25,7 @@ export const dateStringIsValid = (dateString: string): boolean => {
  *
  * @param {metadataObj[]} unfilteredData
  *
- * @returns {metadataObj[]} Filtered metadata, or an empty array.
+ * @return {metadataObj[]} Filtered metadata, or an empty array.
  */
 export const filterMetadata = (unfilteredData: MetadataObj[]): MetadataObj[] => {
   if (unfilteredData.length === 0) {
@@ -57,7 +57,7 @@ export const filterMetadata = (unfilteredData: MetadataObj[]): MetadataObj[] => 
  * Converts any metadata into the correct type.
  * Returns that metadata.
  *
- * @returns {MetadataObj[]} An array of metadata objects.
+ * @return {MetadataObj[]} An array of metadata objects.
  */
 export const fetchPostData = (): MetadataObj[] => {
   const slugs: string[] = fs.readdirSync(path.join(process.cwd(), 'blog'));

--- a/helpers/football/convertForDisplay.tsx
+++ b/helpers/football/convertForDisplay.tsx
@@ -1,0 +1,67 @@
+import { displayTeamColours } from '@/helpers/football/displayTeamColours';
+import { getTeamLogo } from '@/helpers/football/imageFromMapping';
+import { DisplayEntity, DisplayTeam } from '@/types/display/Teams';
+
+/**
+ * Converts the incoming DisplayTeam object into an object for rendering.
+ *
+ * @param {DisplayTeam} singleTeam The DisplayTeam object containing all team data.
+ *
+ * @return {DisplayEntity} The object to be used when displaying a team.
+ */
+export const convertTeamForDisplay = (singleTeam: DisplayTeam): DisplayEntity => {
+  const displayTeamLogo =
+    typeof singleTeam.mapping === 'undefined' || singleTeam.mapping.length === 0
+      ? ''
+      : getTeamLogo(singleTeam.mapping, process.env.NEXT_PUBLIC_ASSET_URL ?? '');
+
+  const displayColours = displayTeamColours(singleTeam.colours ?? {});
+
+  let competitionString =
+    typeof singleTeam.leagueTable === 'undefined' ||
+    singleTeam.leagueTable === null ||
+    Object.keys(singleTeam.leagueTable).length === 0
+      ? ''
+      : singleTeam.leagueTable.competition.name;
+
+  if (
+    typeof singleTeam.leagueTable !== 'undefined' &&
+    singleTeam.leagueTable !== null &&
+    Object.keys(singleTeam.leagueTable).length > 0 &&
+    competitionString !== '' &&
+    singleTeam.leagueTable.competition?.season > 0
+  ) {
+    competitionString = `${competitionString} ${convertSeasonForDisplay(singleTeam.leagueTable?.competition.season)}`;
+  }
+
+  const determinedDisplayName =
+    singleTeam.names.display !== null && singleTeam.names.display !== ''
+      ? singleTeam.names.display
+      : singleTeam.names.full;
+
+  return {
+    id: singleTeam.id,
+    bgColour: displayColours.background,
+    textColour: displayColours.text,
+    detailEnd: competitionString,
+    detailStart: singleTeam.leagueTable?.position?.ordinalNum ?? '',
+    codeName: singleTeam.names.code,
+    displayName: determinedDisplayName,
+    teamLogo: displayTeamLogo,
+  };
+};
+
+/**
+ * A simple function that returns the number in a 'X/X+1' format.
+ *
+ * @param {number|null} season The year of the season, as a number.
+ *
+ * @return {string} The given year plus the
+ */
+export const convertSeasonForDisplay = (season: number | null): string => {
+  if (season === null) {
+    return '';
+  }
+
+  return `${season.toString()}/${(season + 1).toString()}`;
+};

--- a/helpers/football/convertSeasonForDisplay.test.tsx
+++ b/helpers/football/convertSeasonForDisplay.test.tsx
@@ -1,0 +1,13 @@
+import { convertSeasonForDisplay } from './convertForDisplay';
+
+it('a valid number returns the expected X/X+1 response', () => {
+  // Check for Y2K bug.
+  expect(convertSeasonForDisplay(1999)).toEqual('1999/2000');
+  // Year at time of writing.
+  expect(convertSeasonForDisplay(2024)).toEqual('2024/2025');
+  // Not much has changed by we live underwater.
+  expect(convertSeasonForDisplay(3000)).toEqual('3000/3001');
+  // Extreme numbers.
+  expect(convertSeasonForDisplay(-1999)).toEqual('-1999/-1998');
+  expect(convertSeasonForDisplay(0)).toEqual('0/1');
+});

--- a/helpers/football/convertTeamForDisplay.test.tsx
+++ b/helpers/football/convertTeamForDisplay.test.tsx
@@ -1,0 +1,27 @@
+import { DisplayTeam } from '@/types/display/Teams';
+import { convertTeamForDisplay } from './convertForDisplay';
+
+const basicDisplayTeam: DisplayTeam = {
+  id: 123,
+  names: {
+    full: 'Test name',
+    display: 'My test',
+    code: 'TEST',
+    short: 'Test',
+    shortAlt: 'Name',
+    nickName: 'Testy',
+  },
+};
+
+it('a basic display team object should return the minimum response', () => {
+  expect(convertTeamForDisplay(basicDisplayTeam)).toStrictEqual({
+    id: 123,
+    bgColour: 'white',
+    textColour: 'black',
+    codeName: 'TEST',
+    displayName: 'My test',
+    detailEnd: '',
+    detailStart: '',
+    teamLogo: '',
+  });
+});

--- a/helpers/football/displayTeamColours.test.tsx
+++ b/helpers/football/displayTeamColours.test.tsx
@@ -1,0 +1,312 @@
+import { TeamColours } from '@/types/api/Teams';
+import { displayColour, displayTeamColours } from './displayTeamColours';
+
+const defaultResponse: displayColour = {
+  text: 'black',
+  background: 'white',
+};
+
+const recentHome: displayColour = {
+  text: 'rgb(228,231,233)',
+  background: 'rgb(34,107,192)',
+};
+
+const testColours: TeamColours = {
+  '334': {
+    home: {
+      '1': {
+        val: 'rgb(24,72,140)',
+        r: 24,
+        g: 72,
+        b: 140,
+      },
+      '2': {
+        val: 'rgb(13,53,111)',
+        r: 13,
+        g: 53,
+        b: 111,
+      },
+      '3': {
+        val: 'rgb(228,229,231)',
+        r: 228,
+        g: 229,
+        b: 231,
+      },
+      '4': {
+        val: 'rgb(228,229,231)',
+        r: 228,
+        g: 229,
+        b: 231,
+      },
+      split: '4-6,2-6,3-6,1-64,3-6,2-6,4-6',
+    },
+    away: {
+      '1': {
+        val: 'rgb(154,202,173)',
+        r: 154,
+        g: 202,
+        b: 173,
+      },
+      '2': {
+        val: 'rgb(173,225,193)',
+        r: 173,
+        g: 225,
+        b: 193,
+      },
+      '3': {
+        val: 'rgb(132,175,149)',
+        r: 132,
+        g: 175,
+        b: 149,
+      },
+      '4': {
+        val: 'rgb(29,40,67)',
+        r: 29,
+        g: 40,
+        b: 67,
+      },
+      split: '1-34,2-33,3-20,4-9,5-3',
+    },
+    third: {
+      '1': {
+        val: 'rgb(233,116,33)',
+        r: 233,
+        g: 116,
+        b: 33,
+      },
+      '2': {
+        val: 'rgb(45,81,139)',
+        r: 45,
+        g: 81,
+        b: 139,
+      },
+      '3': {
+        val: 'rgb(209,207,209)',
+        r: 209,
+        g: 207,
+        b: 209,
+      },
+      '4': {
+        val: 'rgb(209,207,209)',
+        r: 209,
+        g: 207,
+        b: 209,
+      },
+      split: '2-5,3-5,1-80,3-5,2-5',
+    },
+    season: 2020,
+  },
+  '354': {
+    home: {
+      '1': {
+        val: 'rgb(32,79,149)',
+        r: 32,
+        g: 79,
+        b: 149,
+      },
+      '2': {
+        val: 'rgb(20,35,66)',
+        r: 20,
+        g: 35,
+        b: 66,
+      },
+      '3': {
+        val: 'rgb(235,236,239)',
+        r: 235,
+        g: 236,
+        b: 239,
+      },
+      '4': {
+        val: 'rgb(235,236,239)',
+        r: 235,
+        g: 236,
+        b: 239,
+      },
+      split: '4-5,2-5,3-5,1-70,3-5,2-5,4-5',
+    },
+    away: {
+      '1': {
+        val: 'rgb(235,162,162)',
+        r: 235,
+        g: 162,
+        b: 162,
+      },
+      '2': {
+        val: 'rgb(189,123,123)',
+        r: 189,
+        g: 123,
+        b: 123,
+      },
+      '3': {
+        val: 'rgb(228,224,225)',
+        r: 228,
+        g: 224,
+        b: 225,
+      },
+      '4': {
+        val: 'rgb(128,85,90)',
+        r: 128,
+        g: 85,
+        b: 90,
+      },
+      split: '4-5,3-5,1-20,2-20,1-20,2-20,3-5,4-5',
+    },
+    third: {
+      '1': {
+        val: 'rgb(172,224,192)',
+        r: 172,
+        g: 224,
+        b: 192,
+      },
+      '2': {
+        val: 'rgb(153,201,172)',
+        r: 153,
+        g: 201,
+        b: 172,
+      },
+      '3': {
+        val: 'rgb(132,175,149)',
+        r: 132,
+        g: 175,
+        b: 149,
+      },
+      '4': {
+        val: 'rgb(29,40,67)',
+        r: 29,
+        g: 40,
+        b: 67,
+      },
+      split: '1-37,2-31,3-20,4-9,5-3',
+    },
+    season: 2021,
+  },
+  '374': {
+    home: {
+      '1': {
+        val: 'rgb(34,107,192)',
+        r: 34,
+        g: 107,
+        b: 192,
+      },
+      '2': {
+        val: 'rgb(12,64,126)',
+        r: 12,
+        g: 64,
+        b: 126,
+      },
+      '3': {
+        val: 'rgb(228,231,233)',
+        r: 228,
+        g: 231,
+        b: 233,
+      },
+      '4': {
+        val: 'rgb(228,231,233)',
+        r: 228,
+        g: 231,
+        b: 233,
+      },
+      split: '2-5,3-5,1-80,3-5,2-5',
+    },
+    away: {
+      '1': {
+        val: 'rgb(142,146,155)',
+        r: 142,
+        g: 146,
+        b: 155,
+      },
+      '2': {
+        val: 'rgb(33,33,35)',
+        r: 33,
+        g: 33,
+        b: 35,
+      },
+      '3': {
+        val: 'rgb(115,119,127)',
+        r: 115,
+        g: 119,
+        b: 127,
+      },
+      '4': {
+        val: 'rgb(33,33,35)',
+        r: 33,
+        g: 33,
+        b: 35,
+      },
+      split: '3-10,1-20,2-20,1-20,2-20,3-10',
+    },
+    third: {
+      '1': {
+        val: 'rgb(198,172,191)',
+        r: 198,
+        g: 172,
+        b: 191,
+      },
+      '2': {
+        val: 'rgb(220,191,211)',
+        r: 220,
+        g: 191,
+        b: 211,
+      },
+      '3': {
+        val: 'rgb(135,118,132)',
+        r: 135,
+        g: 118,
+        b: 132,
+      },
+      '4': {
+        val: 'rgb(135,118,132)',
+        r: 135,
+        g: 118,
+        b: 132,
+      },
+      split: '3-10,1-20,2-20,1-20,2-20,3-10',
+    },
+    season: 2022,
+  },
+};
+
+it('returns the default object if an empty object is used', () => {
+  expect(displayTeamColours({})).toStrictEqual(defaultResponse);
+});
+
+it('returns the most recent home colours if no valid compID is provided', () => {
+  expect(displayTeamColours(testColours)).toStrictEqual(recentHome);
+  expect(displayTeamColours(testColours, -123)).toStrictEqual(recentHome);
+  expect(displayTeamColours(testColours, 0)).toStrictEqual(recentHome);
+  expect(displayTeamColours(testColours, 123)).toStrictEqual(recentHome);
+});
+
+it('returns the expected home colours if a valid compID is provided', () => {
+  const firstHome: displayColour = {
+    text: 'rgb(228,229,231)',
+    background: 'rgb(24,72,140)',
+  };
+  const secondHome: displayColour = {
+    text: 'rgb(235,236,239)',
+    background: 'rgb(32,79,149)',
+  };
+
+  expect(displayTeamColours(testColours, 334)).toStrictEqual(firstHome);
+  expect(displayTeamColours(testColours, 354)).toStrictEqual(secondHome);
+  expect(displayTeamColours(testColours, 374)).toStrictEqual(recentHome);
+});
+
+it('returns the expected colours if a valid colour type is provided', () => {
+  const firstAway: displayColour = {
+    text: 'rgb(29,40,67)',
+    background: 'rgb(154,202,173)',
+  };
+  const secondThird: displayColour = {
+    text: 'rgb(29,40,67)',
+    background: 'rgb(172,224,192)',
+  };
+  const recentAway: displayColour = {
+    text: 'rgb(33,33,35)',
+    background: 'rgb(142,146,155)',
+  };
+
+  expect(displayTeamColours(testColours, 334, 'away')).toStrictEqual(firstAway);
+  expect(displayTeamColours(testColours, 354, 'third')).toStrictEqual(secondThird);
+  expect(displayTeamColours(testColours, 374, 'away')).toStrictEqual(recentAway);
+});

--- a/helpers/football/displayTeamColours.tsx
+++ b/helpers/football/displayTeamColours.tsx
@@ -1,0 +1,50 @@
+import { TeamColours } from '@/types/api/Teams';
+
+export type displayColour = {
+  text: string;
+  background: string;
+};
+
+/**
+ * Picks the appropriate colours for the team based on incoming arguments.
+ *
+ * @param colours The object of team colours.
+ * @param compID The ID of the competition.
+ * @param colourType The type of the colour (whether the team is wearing home, away or third colours).
+ *
+ * @return {displayColour} The object containing text and background colours.
+ */
+export const displayTeamColours = (
+  colours: TeamColours,
+  compID: number | null = null,
+  colourType: 'home' | 'away' | 'third' = 'home'
+): displayColour => {
+  const defaultResponse = {
+    text: 'black',
+    background: 'white',
+  };
+
+  const colourKeys = Object.keys(colours);
+
+  if (colourKeys.length === 0) {
+    return defaultResponse;
+  }
+
+  if (compID !== null && compID > 0 && colourKeys.includes(compID.toString())) {
+    return {
+      text: colours[compID][colourType][4].val,
+      background: colours[compID][colourType][1].val,
+    };
+  }
+
+  const lastKey = colourKeys.pop();
+
+  if (typeof lastKey === 'undefined') {
+    return defaultResponse;
+  }
+
+  return {
+    text: colours[lastKey][colourType][4].val,
+    background: colours[lastKey][colourType][1].val,
+  };
+};

--- a/helpers/football/imageFromMapping.test.tsx
+++ b/helpers/football/imageFromMapping.test.tsx
@@ -1,0 +1,44 @@
+import { TeamMapping } from '@/types/api/Teams';
+import { getTeamLogo } from './imageFromMapping';
+
+const testURL = 'https://crouton.net/';
+const testMapping: TeamMapping[] = [
+  {
+    displayName: 'Test',
+    sourceID: '123',
+    sourceName: 'Test',
+    sourceURL: 'https://example.com',
+  },
+  {
+    displayName: 'Testing',
+    sourceID: '456',
+    sourceName: 'OPTA',
+    sourceURL: 'https://example.com',
+  },
+];
+
+const validMapping: TeamMapping[] = [
+  ...testMapping,
+  {
+    displayName: 'Testing',
+    sourceID: '01010101',
+    sourceName: 'FM',
+    sourceURL: 'https://example.com',
+  },
+];
+
+it('returns an empty string if an empty mapping array is provided', () => {
+  expect(getTeamLogo([], testURL)).toBe('');
+});
+
+it('returns an empty string if a mapping array does not contain an FM value', () => {
+  expect(getTeamLogo(testMapping, testURL)).toBe('');
+});
+
+it('returns the expected string if the mapping array contains an FM value', () => {
+  expect(getTeamLogo(validMapping, testURL)).toBe(`${testURL}01010101.png`);
+});
+
+it('returns the expected string if the mapping array contains an FM value, even if there is no trailing slash on our URL', () => {
+  expect(getTeamLogo(validMapping, 'https://crouton.net')).toBe(`${testURL}01010101.png`);
+});

--- a/helpers/football/imageFromMapping.tsx
+++ b/helpers/football/imageFromMapping.tsx
@@ -1,0 +1,21 @@
+import { TeamMapping } from '@/types/api/Teams';
+
+/**
+ * Takes an array of mapping data and filters it to get the 'FM' ID.
+ * Adds that to the URL that contains our logo images.
+ *
+ * @param {TeamMapping[]} mappingData An array of mapping data.
+ * @param {string} assetURL The URL of the logo asset folder.
+ *
+ * @return {string} The URL containing the image.
+ */
+export const getTeamLogo = (mappingData: TeamMapping[], assetURL: string): string => {
+  const reducedMapping = mappingData.filter((singleMap) => singleMap.sourceName === 'FM');
+
+  if (reducedMapping.length === 0) {
+    return '';
+  }
+
+  const slashedURL = assetURL.endsWith('/') ? assetURL : `${assetURL}/`;
+  return `${slashedURL}${reducedMapping[0].sourceID}.png`;
+};

--- a/types/api/Generic.tsx
+++ b/types/api/Generic.tsx
@@ -1,0 +1,7 @@
+export type JSONValue = string | number | boolean | JSONObject | JSONArray;
+
+export interface JSONObject {
+  [x: string]: JSONValue;
+}
+
+export interface JSONArray extends Array<JSONValue> {}

--- a/types/api/Teams.tsx
+++ b/types/api/Teams.tsx
@@ -1,0 +1,95 @@
+export type TeamNames = {
+  full: string;
+  display: string;
+  short: string;
+  shortAlt: string;
+  nickName: string;
+  code: string;
+};
+
+export type TeamCompetition = {
+  id: number;
+  name: string;
+  master: number;
+  season: number;
+  participants: number;
+  rounds: number;
+  separator: string;
+  score: number;
+};
+
+export type SingleColour = {
+  val: string;
+  r: number;
+  g: number;
+  b: number;
+};
+
+export type SingleColourObj = {
+  1: SingleColour;
+  2: SingleColour;
+  3: SingleColour;
+  4: SingleColour;
+  split: string;
+};
+
+export type TeamColours = {
+  [key: string]: {
+    home: SingleColourObj;
+    away: SingleColourObj;
+    third: SingleColourObj;
+    season: number;
+  };
+};
+
+export type TeamLeague = {
+  competition: TeamCompetition;
+  position: {
+    ordinal: string;
+    ordinalNum: string;
+    value: number;
+    std: number;
+  };
+  positionDiff: {
+    value: number;
+    std: number;
+  };
+  played: number;
+  points: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  goals: number;
+  h2h: number;
+  perGame: {
+    points: number;
+    goalsFor: number;
+    goalsAgainst: number;
+    goalsDiff: number;
+  };
+};
+
+export type TeamMapping = {
+  displayName: string;
+  sourceName: string;
+  sourceID: string;
+  sourceURL: string;
+};
+
+export type SingleTeam = {
+  id: number;
+  name: string;
+  type: 'club' | 'national';
+  colours: TeamColours;
+  competitionHistory: TeamCompetition[];
+  logo: string;
+  leagueTable: TeamLeague;
+  mapping: TeamMapping[];
+  names: TeamNames;
+};
+
+export type Teams = {
+  teams: SingleTeam[];
+  limit: number;
+  currentPage: number;
+};

--- a/types/display/Teams.tsx
+++ b/types/display/Teams.tsx
@@ -1,0 +1,20 @@
+import { TeamColours, TeamLeague, TeamMapping, TeamNames } from '@/types/api/Teams';
+
+export type DisplayTeam = {
+  id: number;
+  names: TeamNames;
+  leagueTable?: TeamLeague;
+  mapping?: TeamMapping[];
+  colours?: TeamColours;
+};
+
+export type DisplayEntity = {
+  id: number;
+  bgColour?: string;
+  textColour?: string;
+  detailEnd?: string;
+  detailStart?: string;
+  codeName?: string;
+  displayName?: string;
+  teamLogo?: string;
+};


### PR DESCRIPTION
- adds the initial team page, containing basic data
- adds a simple team list page
- data pulls in from the external API, using authentication
- test coverage for new functions
- Storybook now gets deployed as part of the build